### PR TITLE
Fix: Prevent max update depth error by removing canvas transitions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -935,7 +935,7 @@ export default function EnhancedGraphPaper() {
     <div className="w-screen h-screen overflow-hidden relative bg-gradient-to-br from-slate-50 to-slate-100 touch-none">
       <canvas
         ref={canvasRef}
-        className={`absolute top-0 left-0 w-full h-full transition-all duration-200 touch-none ${
+        className={`absolute top-0 left-0 w-full h-full touch-none ${
           tool === "pan" ? "cursor-grab" : tool === "eraser" ? "cursor-crosshair" : "cursor-crosshair"
         } ${isPanning ? "cursor-grabbing" : ""}`}
         onMouseDown={(e) => handlePointerDown(getCanvasPoint(e), e.shiftKey)}


### PR DESCRIPTION
The "Maximum update depth exceeded" error occurring during mouse movements on the canvas was likely due to layout instability. The `transition-all` CSS property on the canvas element could cause `getBoundingClientRect()` to return fluctuating values during rapid state updates and re-renders triggered by pointer events. This, in turn, could feed back into the state updates, leading to an infinite loop.

This commit removes `transition-all` and `duration-200` from the canvas element's className to stabilize its layout during pointer interactions, resolving the update loop.