### PR TITLE
Fix touchmove listener scope

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -889,9 +889,11 @@ export default function EnhancedGraphPaper() {
   }, [tool, activeShapeStartPoint, arcPoints, eraserMode])
 
   useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
     const preventDefault = (e: TouchEvent) => e.preventDefault()
-    document.addEventListener("touchmove", preventDefault, { passive: false })
-    return () => document.removeEventListener("touchmove", preventDefault)
+    canvas.addEventListener("touchmove", preventDefault, { passive: false })
+    return () => canvas.removeEventListener("touchmove", preventDefault)
   }, [])
 
   const handleDownload = useCallback(() => {


### PR DESCRIPTION
## Summary
- attach `touchmove` listener to the canvas element instead of the whole document

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c98a47a78832ab0018dfc298780f6