### PR TITLE
Add manifest and service worker

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import "./globals.css" // Ensure your global styles are imported
 import { ThemeProvider } from "@/components/theme-provider" // Assuming you have a theme provider
+import ServiceWorkerRegister from "@/components/service-worker-register"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -35,8 +36,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <head />
+      <head>
+        <link rel="manifest" href="/manifest.webmanifest" />
+        <meta name="theme-color" content="#ffffff" />
+      </head>
       <body className={inter.className}>
+        <ServiceWorkerRegister />
         <ThemeProvider attribute="class" defaultTheme="system" enableSystemTransition disableTransitionOnChange>
           {children}
         </ThemeProvider>

--- a/components/service-worker-register.tsx
+++ b/components/service-worker-register.tsx
@@ -1,0 +1,8 @@
+"use client"
+
+import { useServiceWorker } from "@/hooks/use-service-worker"
+
+export default function ServiceWorkerRegister() {
+  useServiceWorker()
+  return null
+}

--- a/hooks/use-service-worker.ts
+++ b/hooks/use-service-worker.ts
@@ -1,0 +1,13 @@
+"use client"
+
+import { useEffect } from "react"
+
+export function useServiceWorker() {
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
+      navigator.serviceWorker
+        .register("/sw.js")
+        .catch((err) => console.error("SW registration failed", err))
+    }
+  }, [])
+}

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "Graph Paper",
+  "short_name": "Graph Paper",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/placeholder-logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "/placeholder-logo.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,39 @@
+const CACHE_NAME = 'offline-cache-v1';
+const ASSETS = [
+  '/',
+  '/manifest.webmanifest',
+  '/placeholder-logo.png',
+  '/placeholder-logo.svg'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request)
+        .then(response => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(() => caches.match('/'));
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add PWA manifest referencing placeholder icons
- register a service worker for offline support
- inject manifest link and theme-color meta in root layout
- avoid storing binary icons in the repo

## Testing
- `pnpm install`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_684c98a59aa4832ab06eb55d7c60cc10