### PR TITLE
fix: Correct addToHistory call for rectangles

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -863,6 +863,7 @@ export default function EnhancedGraphPaper() {
               }
 
               addToHistory({
+                ...currentState, // Add this spread operator
                 rectangles: [...currentState.rectangles, newRectangle],
                 lines: [...currentState.lines, ...newLinesForTrusses],
                 walls: [...currentState.walls, ...newWallsFromRect],


### PR DESCRIPTION
Ensures that when a rectangle (and its associated walls/trusses) is added to history, the ...currentState spread operator is used in the addToHistory call.

This prevents the accidental omission or reset of other element arrays (like arcs, circles, texts) in the new history state. Previously, if newLinesForTrusses and newWallsFromRect were empty, it could lead to other shape data being lost from that history snapshot.