### PR TITLE
fix: Adjust fullscreen button position to prevent overlap with toolbar

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1341,7 +1341,7 @@ export default function EnhancedGraphPaper() {
         }}
       />
 
-      <div className="absolute top-6 right-6 z-10">
+      <div className="absolute top-6 right-24 z-10">
         <Button
           variant="ghost"
           size="icon"


### PR DESCRIPTION
The fullscreen button was previously obscured by the main toolbar on desktop viewports due to both elements sharing the same absolute positioning (top-6, right-6).

This commit moves the fullscreen button further to the left by changing its horizontal position from `right-6` to `right-24`. This ensures it is visible and accessible next to the toolbar on desktop.

The mobile layout is unaffected as the toolbar is positioned at the bottom of the screen in that context.