### PR TITLE
Remove unused Floor import

### DIFF
--- a/src/tools/FloorTool.tsx
+++ b/src/tools/FloorTool.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import useStore from '@/src/model/useStore'; // Adjusted path based on tsconfig alias
-import { Point, Floor } from '@/src/model/types'; // Adjusted path
+import { Point } from '@/src/model/types'; // Adjusted path
 
 // Props for the FloorTool - to be expanded as canvas interaction is defined
 interface FloorToolProps {


### PR DESCRIPTION
## Summary
- cleanup: remove unused Floor import from FloorTool

## Testing
- `pnpm install`
- `pnpm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685564f47390832abca66c7e9792d0fa