### PR TITLE
Remove invalid wall type checks in OpeningTool

### DIFF
--- a/src/tools/OpeningTool.tsx
+++ b/src/tools/OpeningTool.tsx
@@ -36,8 +36,9 @@ const OpeningTool: React.FC<OpeningToolProps> = ({
       // For now, default based on type or keep simple default
       setType('window');
       setWidth(1);
-      setHeight(selectedWall.type === 'door' ? 2.1 : 1.2);
-      setElevation(selectedWall.type === 'door' ? 0 : 0.8);
+      // Default opening dimensions regardless of wall type
+      setHeight(1.2);
+      setElevation(0.8);
       setPosition(1); // Default to 1 unit from start. User should adjust.
     } else if (!isActive) {
         onClose(); // Ensure form is hidden if tool becomes inactive


### PR DESCRIPTION
## Summary
- default window height and elevation independently of wall type

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_685564f338fc832a9a2da7c94bf25d50