### PR TITLE
Add wire cost summary selector and export support

### DIFF
--- a/src/export/exportUtils.ts
+++ b/src/export/exportUtils.ts
@@ -5,6 +5,7 @@ import useStore from '@/src/model/useStore';
  */
 export function downloadJSON() {
   const state = useStore.getState();
+  const wireSummary = state.selectWireUsageSummary();
 
   // Create a serializable version of the state.
   // The Zustand store might contain functions (actions, selectors).
@@ -15,6 +16,8 @@ export function downloadJSON() {
     flatPieces: state.flatPieces,
     connections: state.connections,
     settings: state.settings,
+    wireRuns: state.wireRuns,
+    wireUsageSummary: wireSummary,
   };
 
   const jsonString = JSON.stringify(modelData, null, 2);

--- a/src/model/useStore.ts
+++ b/src/model/useStore.ts
@@ -128,6 +128,11 @@ interface StoreSelectors {
   selectElectricalCircuits: () => ElectricalCircuit[];
   selectElectricalPanels: () => ElectricalPanel[];
   selectWireRuns: () => WireRun[];
+  selectWireUsageSummary: () => {
+    totalCost: number;
+    totalLength: number;
+    wireTypes: { [key: string]: { length: number; cost: number } };
+  };
   selectElectricalProject: () => ElectricalProject | undefined;
   selectPlumbingFixtures: () => PlumbingFixture[];
   selectPlumbingPipes: () => PlumbingPipe[];
@@ -510,6 +515,24 @@ const useStore = create<StoreState>()(
     selectElectricalCircuits: () => get().electricalCircuits,
     selectElectricalPanels: () => get().electricalPanels,
     selectWireRuns: () => get().wireRuns,
+    selectWireUsageSummary: () => {
+      const summary: { totalCost: number; totalLength: number; wireTypes: { [key: string]: { length: number; cost: number } } } = {
+        totalCost: 0,
+        totalLength: 0,
+        wireTypes: {}
+      };
+      const runs = get().wireRuns;
+      runs.forEach((run) => {
+        summary.totalCost += run.cost;
+        summary.totalLength += run.length;
+        if (!summary.wireTypes[run.wireType]) {
+          summary.wireTypes[run.wireType] = { length: 0, cost: 0 };
+        }
+        summary.wireTypes[run.wireType].length += run.length;
+        summary.wireTypes[run.wireType].cost += run.cost;
+      });
+      return summary;
+    },
     selectElectricalProject: () => get().electricalProject,
     selectPlumbingFixtures: () => get().plumbingFixtures,
     selectPlumbingPipes: () => get().plumbingPipes,

--- a/src/tools/WiringTool.tsx
+++ b/src/tools/WiringTool.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import useStore from '@/src/model/useStore';
-import { Point, ElectricalOutlet, ElectricalSwitch, ElectricalCircuit, WireRun, FlatPiece } from '@/src/model/types';
+import { Point, ElectricalOutlet, ElectricalSwitch, ElectricalCircuit, FlatPiece } from '@/src/model/types';
 import { WireRoutingEngine, ElectricalCodeChecker } from './WireRoutingUtils';
-import { formatMeasurement, calculateAreaDisplay } from './MeasurementUtils';
+import { formatMeasurement } from './MeasurementUtils';
 
 interface WiringToolProps {
   isActive: boolean;
@@ -23,13 +23,13 @@ const WiringTool: React.FC<WiringToolProps> = ({
     addElectricalCircuit,
     addElectricalPanel,
     addWireRun,
-    updateWirePrices,
     selectFlatPieces,
     selectElectricalOutlets,
     selectElectricalSwitches,
     selectElectricalCircuits,
     selectElectricalPanels,
     selectWireRuns,
+    selectWireUsageSummary,
     selectSettings
   } = useStore();
 
@@ -49,6 +49,7 @@ const WiringTool: React.FC<WiringToolProps> = ({
   const circuits = selectElectricalCircuits();
   const panels = selectElectricalPanels();
   const wireRuns = selectWireRuns();
+  const wireUsageSummary = selectWireUsageSummary();
   const settings = selectSettings();
 
   // Get walls from flat pieces
@@ -58,28 +59,6 @@ const WiringTool: React.FC<WiringToolProps> = ({
   const wireRoutingEngine = useMemo(() => {
     return new WireRoutingEngine(walls, settings.gridSize);
   }, [walls, settings.gridSize]);
-
-  // Calculate total wire costs and usage
-  const wireUsageSummary = useMemo(() => {
-    const summary = {
-      totalCost: 0,
-      totalLength: 0,
-      wireTypes: {} as { [key: string]: { length: number; cost: number } }
-    };
-
-    wireRuns.forEach((run: WireRun) => {
-      summary.totalCost += run.cost;
-      summary.totalLength += run.length;
-      
-      if (!summary.wireTypes[run.wireType]) {
-        summary.wireTypes[run.wireType] = { length: 0, cost: 0 };
-      }
-      summary.wireTypes[run.wireType].length += run.length;
-      summary.wireTypes[run.wireType].cost += run.cost;
-    });
-
-    return summary;
-  }, [wireRuns]);
 
   // Check electrical code compliance
   const codeViolations = useMemo(() => {


### PR DESCRIPTION
## Summary
- expose a `selectWireUsageSummary` selector for computing total wire cost and length
- render aggregated wire totals in the wiring tool's panel
- include wire runs and cost summary in exported JSON reports

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_689a28e0aa84832a876f34577c3bb222