### PR TITLE
Add basic Three.js viewer and mesh builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,19 @@ Transform your 2D floor plans into stunning 3D models with just a few clicks!
    npm run dev
    \`\`\`
 
-2. **Open the Floor Plan Designer:**
-   Navigate to `http://localhost:3000/three`
+2. **Open the editor:**
+   Navigate to `http://localhost:3000/three`.
 
-3. **Design your floor plan:**
-   - Press **F** to activate Floor tool - click to add points, click near first point to close
-   - Press **W** to activate Wall tool - click start, then end points to draw walls
-   - Press **S** for Select tool to interact with elements
-   - Press **ESC** to cancel current drawing
+3. **Design your floor plan in 2D:**
+   - Press **F** to activate the Floor tool. Click to add points and close the shape.
+   - Press **W** to activate the Wall tool. Click start and end points to draw walls.
+   - Press **S** for Select, **M** for Measure, or **T** for Text.
+   - Press **ESC** to cancel the current drawing.
 
-4. **Connect walls:**
-   - Click "Auto-Connect Walls" to automatically connect nearby endpoints
-   - Connected walls show in green with orange connection indicators
-
-5. **Build your 3D model:**
-   - Click "Build 3D Model" to see your creation in 3D!
-   - Use mouse to orbit, zoom, and explore
+4. **View in 3D:**
+   - Click **"Switch to 3D"** to see your plan rendered in Three.js.
+   - Use the mouse to orbit, zoom, and explore.
+   - Click **"Switch to 2D"** to return to editing.
 
 ## Features
 - **2D Floor Plan Designer:** Intuitive click-to-draw interface

--- a/app/three/page.tsx
+++ b/app/three/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Canvas2D } from '@/src/components/Canvas2D';
+import { Viewer } from '@/src/three/Viewer';
+
+type Tool = 'floor' | 'wall' | 'select' | 'measure' | 'text' | null;
+
+export default function ThreePage() {
+  const [mode, setMode] = useState<'2d' | '3d'>('2d');
+  const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
+  const [activeTool, setActiveTool] = useState<Tool>('select');
+
+  useEffect(() => {
+    const update = () => setDimensions({ width: window.innerWidth, height: window.innerHeight - 40 });
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (key === 'f') setActiveTool('floor');
+      if (key === 'w') setActiveTool('wall');
+      if (key === 's') setActiveTool('select');
+      if (key === 'm') setActiveTool('measure');
+      if (key === 't') setActiveTool('text');
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, []);
+
+  return (
+    <div className="w-full h-screen flex flex-col">
+      <div className="p-2">
+        <button className="border px-2 py-1" onClick={() => setMode(mode === '2d' ? '3d' : '2d')}>
+          {mode === '2d' ? 'Switch to 3D' : 'Switch to 2D'}
+        </button>
+      </div>
+      <div className="flex-1">
+        {mode === '2d' ? (
+          <Canvas2D width={dimensions.width} height={dimensions.height} activeTool={activeTool} />
+        ) : (
+          <Viewer />
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/three/Viewer.tsx
+++ b/src/three/Viewer.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import useStore from '@/src/model/useStore';
+import { wallToMesh, floorToMesh } from './meshes';
+
+export function Viewer() {
+  const walls = useStore((state) => state.walls);
+  const floors = useStore((state) => state.floors);
+
+  const wallMeshes = useMemo(() => walls.map(wallToMesh), [walls]);
+  const floorMeshes = useMemo(() => floors.map(floorToMesh), [floors]);
+
+  return (
+    <Canvas camera={{ position: [10, 10, 10], fov: 50 }} style={{ width: '100%', height: '100%' }}>
+      <ambientLight intensity={0.5} />
+      <directionalLight position={[10, 10, 5]} intensity={1} />
+      {floorMeshes.map((mesh, i) => (
+        <primitive object={mesh} key={`floor-${floors[i].id}`} />
+      ))}
+      {wallMeshes.map((mesh, i) => (
+        <primitive object={mesh} key={`wall-${walls[i].id}`} />
+      ))}
+      <gridHelper args={[50, 50]} />
+      <OrbitControls />
+    </Canvas>
+  );
+}
+
+export default Viewer;
+

--- a/src/three/meshes.ts
+++ b/src/three/meshes.ts
@@ -1,0 +1,58 @@
+import * as THREE from 'three';
+import { Wall, Floor } from '@/src/model/types';
+
+/**
+ * Create a Three.js mesh representing a wall.
+ * The wall is modelled as a box extruded between start and end points
+ * with the given height and thickness.
+ */
+export function wallToMesh(wall: Wall): THREE.Mesh {
+  const dx = wall.end.x - wall.start.x;
+  const dy = wall.end.y - wall.start.y;
+  const length = Math.sqrt(dx * dx + dy * dy);
+
+  // Box geometry: length along X, height along Y, thickness along Z
+  const geometry = new THREE.BoxGeometry(length, wall.height, wall.thickness);
+  const material = new THREE.MeshStandardMaterial({ color: 0xcccccc });
+  const mesh = new THREE.Mesh(geometry, material);
+
+  // Position wall at midpoint and rotate to match direction
+  const midX = (wall.start.x + wall.end.x) / 2;
+  const midZ = (wall.start.y + wall.end.y) / 2;
+  mesh.position.set(midX, wall.height / 2, midZ);
+
+  const angle = Math.atan2(dy, dx);
+  mesh.rotation.y = angle;
+
+  return mesh;
+}
+
+/**
+ * Create a Three.js mesh representing a floor polygon extruded to thickness.
+ */
+export function floorToMesh(floor: Floor): THREE.Mesh {
+  const shape = new THREE.Shape();
+  if (floor.points.length > 0) {
+    const first = floor.points[0];
+    shape.moveTo(first.x, first.y);
+    for (let i = 1; i < floor.points.length; i++) {
+      const p = floor.points[i];
+      shape.lineTo(p.x, p.y);
+    }
+    shape.closePath();
+  }
+
+  const geometry = new THREE.ExtrudeGeometry(shape, {
+    depth: floor.thickness,
+    bevelEnabled: false,
+  });
+  const material = new THREE.MeshStandardMaterial({ color: 0x999999 });
+  const mesh = new THREE.Mesh(geometry, material);
+
+  // Rotate so that extrusion is vertical (along Y)
+  mesh.rotation.x = -Math.PI / 2;
+  mesh.position.y = floor.elevation;
+
+  return mesh;
+}
+


### PR DESCRIPTION
## Summary
- add utilities to convert walls and floors into Three.js meshes
- create Viewer component that renders walls and floors from the Zustand store
- add `/three` page with toggle between 2D canvas and 3D viewer
- update Quick Start guide in README

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_689a28ded454832aa5375725d45db9cc