### PR TITLE
Add material estimator and track stud costs

### DIFF
--- a/src/export/exportUtils.ts
+++ b/src/export/exportUtils.ts
@@ -15,6 +15,7 @@ export function downloadJSON() {
     flatPieces: state.flatPieces,
     connections: state.connections,
     settings: state.settings,
+    materials: state.materials,
   };
 
   const jsonString = JSON.stringify(modelData, null, 2);

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -211,6 +211,13 @@ export interface TextElement {
   rotation: number; // in degrees
 }
 
+export interface MaterialsEstimate {
+  totalWallLength: number;
+  studCount: number;
+  studPrice: number;
+  totalStudCost: number;
+}
+
 export interface Model {
   measurements: Measurement[];
   textElements: TextElement[];
@@ -231,6 +238,7 @@ export interface Model {
   plumbingFixtures: PlumbingFixture[];
   plumbingPipes: PlumbingPipe[];
   buildingCodeViolations: BuildingCodeViolation[];
+  materials: MaterialsEstimate;
   settings: {
     gridVisible: boolean;
     gridSize: number;

--- a/src/tools/MaterialEstimator.ts
+++ b/src/tools/MaterialEstimator.ts
@@ -1,0 +1,35 @@
+import { Wall, MaterialsEstimate } from '../model/types';
+
+// Represents 16 inches (16/12 feet)
+export const STUD_SPACING_UNITS = 1.33;
+
+/**
+ * Calculates material requirements based on wall definitions.
+ * @param walls - Array of walls from the store.
+ * @param studPrice - Cost per individual stud.
+ * @returns Material estimates including totals and cost.
+ */
+export function estimateMaterials(
+  walls: Wall[],
+  studPrice: number = 0
+): MaterialsEstimate {
+  const totalWallLength = walls.reduce((sum, wall) => {
+    const dx = wall.end.x - wall.start.x;
+    const dy = wall.end.y - wall.start.y;
+    return sum + Math.hypot(dx, dy);
+  }, 0);
+
+  const studCount =
+    totalWallLength > 0
+      ? Math.floor(totalWallLength / STUD_SPACING_UNITS) + 1
+      : 0;
+
+  const totalStudCost = studCount * studPrice;
+
+  return {
+    totalWallLength,
+    studCount,
+    studPrice,
+    totalStudCost,
+  };
+}


### PR DESCRIPTION
## Summary
- add MaterialEstimator utility to calculate wall length and studs
- extend store model with materials data and live updates on wall edits
- include materials summary in export JSON

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_689a28e31070832a926d2a5fc53cad95