### PR TITLE
Refactor text editing overlay and remove debug logs

### DIFF
--- a/components/projects/ProjectsModal.tsx
+++ b/components/projects/ProjectsModal.tsx
@@ -33,8 +33,6 @@ export function ProjectsModal({
 
   useEffect(() => {
     if (isOpen && user) {
-      console.log('ProjectsModal opened with user:', user)
-      console.log('User ID:', user.id)
       loadProjects()
     }
   }, [isOpen, user])
@@ -43,7 +41,6 @@ export function ProjectsModal({
     setLoading(true)
     setError('') // Clear any previous errors
     try {
-      console.log('Loading projects for user_id:', user.id)
       
       const { data, error } = await supabase
         .from('projects')
@@ -56,8 +53,6 @@ export function ProjectsModal({
         throw error
       }
       
-      console.log('Projects loaded:', data)
-      console.log('Number of projects:', data?.length || 0)
       
       setProjects(data || [])
     } catch (error: any) {
@@ -77,8 +72,6 @@ export function ProjectsModal({
     setSaving(true)
     setError('') // Clear any previous errors
     try {
-      console.log('Saving project with user_id:', user.id)
-      console.log('Project data:', { title: newProjectTitle.trim(), description: newProjectDescription.trim() })
       
       const { data, error } = await supabase
         .from('projects')
@@ -95,7 +88,6 @@ export function ProjectsModal({
         throw error
       }
       
-      console.log('Project saved successfully:', data)
       
       setNewProjectTitle('')
       setNewProjectDescription('')
@@ -103,7 +95,6 @@ export function ProjectsModal({
       
       // Reload projects to show the new one
       await loadProjects()
-      console.log('Projects reloaded after save')
     } catch (error: any) {
       console.error('Save project error:', error)
       setError(error.message)
@@ -129,12 +120,9 @@ export function ProjectsModal({
   }
 
   const loadProject = (project: Project) => {
-    console.log('Loading project:', project.title)
-    console.log('Project canvas data:', project.canvas_data)
     try {
       onLoadProject(project.canvas_data, project.id, project.title)
       onClose()
-      console.log('Project loaded successfully')
     } catch (error) {
       console.error('Error loading project:', error)
       setError('Failed to load project: ' + (error as Error).message)

--- a/src/components/GraphCanvas.tsx
+++ b/src/components/GraphCanvas.tsx
@@ -20,6 +20,7 @@ import useStore from '@/src/model/useStore';
 import { formatMeasurement } from '@/src/tools/MeasurementUtils';
 import WiringPanel from './WiringPanel';
 import PlumbingPanel from './PlumbingPanel';
+import TextInputOverlay from './TextInputOverlay';
 import {
   PenLine,
   Move,
@@ -333,7 +334,6 @@ export default function GraphCanvas() {
   const [keepMeasurements, setKeepMeasurements] = useState(false);
   const [isTextEditing, setIsTextEditing] = useState(false);
   const [textInputStartTime, setTextInputStartTime] = useState<number>(0);
-  const textInputRef = useRef<HTMLInputElement>(null);
 
   // Authentication and modal states
   const { user, loading: authLoading, signOut, isAuthenticated } = useAuth();
@@ -1339,13 +1339,9 @@ export default function GraphCanvas() {
       setEraserStrokePoints([worldPoint]);
     } else if (tool === 'text') {
       // Simple text tool implementation
-      console.log('=== TEXT TOOL CLICKED ===');
-      console.log('Current editingText state:', editingText);
-      console.log('Click position:', point);
       
       // If already editing, save the current text first
       if (editingText) {
-        console.log('Already editing text, saving current text first');
         if (editingText.currentText.trim()) {
           const worldPosition = getWorldPoint(editingText.position);
           addToHistory({
@@ -1359,12 +1355,10 @@ export default function GraphCanvas() {
               },
             ],
           });
-          console.log('Saved text:', editingText.currentText.trim());
         }
       }
       
              // Start new text input
-       console.log('Starting new text input');
        setEditingText({
          position: point,
          currentText: '',
@@ -1797,14 +1791,9 @@ export default function GraphCanvas() {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      console.log('=== KEYDOWN EVENT ===');
-      console.log('Key pressed:', e.key);
-      console.log('isTextEditing:', isTextEditing);
-      console.log('editingText:', editingText);
       
       // Guard against undefined key
       if (!e.key) {
-        console.log('Key is undefined, ignoring event');
         return;
       }
       
@@ -1821,10 +1810,8 @@ export default function GraphCanvas() {
 
       // Handle text editing - HIGHEST PRIORITY
       if (isTextEditing && editingText) {
-        console.log('In text editing mode, handling key:', e.key);
         
         if (e.key === 'Enter') {
-          console.log('Enter pressed - saving text');
           e.preventDefault();
           e.stopPropagation();
           
@@ -1841,7 +1828,6 @@ export default function GraphCanvas() {
                 },
               ],
             });
-            console.log('Text saved successfully:', editingText.currentText.trim());
           }
           
           setEditingText(null);
@@ -1850,7 +1836,6 @@ export default function GraphCanvas() {
         }
         
         if (e.key === 'Escape') {
-          console.log('Escape pressed - canceling text');
           e.preventDefault();
           e.stopPropagation();
           setEditingText(null);
@@ -1859,18 +1844,15 @@ export default function GraphCanvas() {
         }
         
         // For all other keys during text editing, let them through normally
-        console.log('Allowing key through for text input:', e.key);
         return;
       }
 
       // If user is typing in any input field, don't handle tool shortcuts
       if (isTypingInInput) {
-        console.log('User is typing in an input field, ignoring tool shortcuts');
         return;
       }
 
       // Only handle tool shortcuts if NOT editing text
-      console.log('Not editing text, checking for tool shortcuts');
       
       // Handle measure tool shortcuts
       if (tool === 'measure' && pressedKey === 'enter') {
@@ -1900,7 +1882,6 @@ export default function GraphCanvas() {
         (t) => t.shortcut && t.shortcut.toLowerCase() === pressedKey,
       );
       if (toolToSelect && !e.metaKey && !e.ctrlKey && !e.altKey) {
-        console.log('Tool shortcut matched:', pressedKey, '-> switching to:', toolToSelect.name);
         e.preventDefault();
         if (toolToSelect.name === 'fullscreen') {
           toggleFullscreen();
@@ -1938,7 +1919,6 @@ export default function GraphCanvas() {
         if (currentProjectId) {
           (async () => {
             try {
-              console.log('Updating existing project:', currentProjectTitle, currentProjectId);
               
               const { error } = await supabase
                 .from('projects')
@@ -1950,7 +1930,6 @@ export default function GraphCanvas() {
 
               if (error) throw error;
               
-              console.log('Project updated successfully');
               triggerFeedback();
               
               // Show a brief success message
@@ -1965,7 +1944,6 @@ export default function GraphCanvas() {
           })();
         } else {
           // No current project, open modal to create new one
-          console.log('No current project, opening save dialog');
           setIsProjectsModalOpen(true);
         }
       } else if (pressedKey === 'g' && !e.metaKey && !e.ctrlKey && !e.altKey) {
@@ -2251,7 +2229,6 @@ export default function GraphCanvas() {
   }, [triggerFeedback]);
 
   const handleLoadProject = useCallback((projectData: any, projectId?: string, projectTitle?: string) => {
-    console.log('handleLoadProject called with data:', projectData);
     
     if (projectData && typeof projectData === 'object') {
       // Ensure all required arrays exist in the loaded data
@@ -2269,7 +2246,6 @@ export default function GraphCanvas() {
         plumbingPipes: projectData.plumbingPipes || [],
       };
       
-      console.log('Setting loaded state:', loadedState);
       setHistory([loadedState]);
       setHistoryIndex(0);
       
@@ -2277,11 +2253,9 @@ export default function GraphCanvas() {
       if (projectId && projectTitle) {
         setCurrentProjectId(projectId);
         setCurrentProjectTitle(projectTitle);
-        console.log('Set current project:', projectTitle, projectId);
       }
       
       triggerFeedback();
-      console.log('Project loaded and history updated');
     } else {
       console.error('Invalid project data:', projectData);
     }
@@ -2296,7 +2270,6 @@ export default function GraphCanvas() {
     // If we have a current project, update it
     if (currentProjectId) {
       try {
-        console.log('Updating existing project:', currentProjectTitle, currentProjectId);
         
         const { error } = await supabase
           .from('projects')
@@ -2308,7 +2281,6 @@ export default function GraphCanvas() {
 
         if (error) throw error;
         
-        console.log('Project updated successfully');
         triggerFeedback();
         
         // Show a brief success message
@@ -2322,7 +2294,6 @@ export default function GraphCanvas() {
       }
     } else {
       // No current project, open modal to create new one
-      console.log('No current project, opening save dialog');
       setIsProjectsModalOpen(true);
     }
   }, [isAuthenticated, currentProjectId, currentProjectTitle, currentState, triggerFeedback, setStatusMessage]);
@@ -2370,26 +2341,44 @@ export default function GraphCanvas() {
     triggerFeedback();
   };
 
-  // Debug editingText changes and handle focus
-  useEffect(() => {
-    console.log('=== EDITING TEXT STATE CHANGED ===');
-    console.log('New editingText state:', editingText);
+  const handleTextChange = (value: string) => {
     if (editingText) {
-      console.log('Text content:', editingText.currentText);
-      console.log('Text position:', editingText.position);
-      
-      // Focus the input when editingText is first created (only when text is empty)
-      if (editingText.currentText === '' && textInputRef.current) {
-        console.log('Focusing new text input');
-        setTimeout(() => {
-          if (textInputRef.current && editingText && editingText.currentText === '') {
-            textInputRef.current.focus();
-            // Don't select all text - just focus
-          }
-        }, 50);
-      }
+      setEditingText({ ...editingText, currentText: value });
     }
-  }, [editingText]);
+  };
+
+  const handleTextBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const timeSinceStart = Date.now() - textInputStartTime;
+    const hasText = editingText && editingText.currentText.trim();
+
+    if (timeSinceStart < 200 && !hasText) {
+      setTimeout(() => e.target.focus(), 10);
+      return;
+    }
+
+    if (editingText && hasText) {
+      const worldPosition = getWorldPoint(editingText.position);
+      addToHistory({
+        texts: [
+          ...currentState.texts,
+          {
+            position: worldPosition,
+            text: editingText.currentText.trim(),
+            color: currentColor,
+            fontSize: 16,
+          },
+        ],
+      });
+    }
+    setEditingText(null);
+    setIsTextEditing(false);
+  };
+
+  const handleTextKeyDown = (_: React.KeyboardEvent<HTMLInputElement>) => {
+    // Global keyboard handler manages Enter and Escape
+  };
+
+  // Text input overlay handles its own focus
 
   // Render Traditional Graph Paper Mode (default)
   return (
@@ -2686,73 +2675,11 @@ export default function GraphCanvas() {
 
       {/* Text Editing Input */}
       {editingText && (
-        <input
-          ref={textInputRef}
-          type="text"
-          value={editingText.currentText}
-          onChange={(e) => {
-            console.log('=== TEXT INPUT CHANGE ===');
-            console.log('Input value:', e.target.value);
-            console.log('Current editingText state:', editingText);
-            console.log('Setting new text state...');
-            setEditingText({ ...editingText, currentText: e.target.value });
-            console.log('Text state updated');
-          }}
-          onFocus={() => {
-            console.log('Text input focused');
-          }}
-          onBlur={(e) => {
-            console.log('Text input blurred, saving text');
-            
-            // Prevent immediate blur - only allow blur if enough time has passed or if there's actual text
-            const timeSinceStart = Date.now() - textInputStartTime;
-            const hasText = editingText && editingText.currentText.trim();
-            
-            if (timeSinceStart < 200 && !hasText) {
-              console.log('Preventing immediate blur - refocusing input');
-              // Refocus the input if blur happened too quickly
-              setTimeout(() => {
-                const input = e.target as HTMLInputElement;
-                if (input && editingText) {
-                  input.focus();
-                }
-              }, 10);
-              return;
-            }
-            
-            // Only save if we actually have some text
-            if (hasText) {
-              const worldPosition = getWorldPoint(editingText.position);
-              addToHistory({
-                texts: [
-                  ...currentState.texts,
-                  {
-                    position: worldPosition,
-                    text: editingText.currentText.trim(),
-                    color: currentColor,
-                    fontSize: 16,
-                  },
-                ],
-              });
-              console.log('Text saved on blur:', editingText.currentText.trim());
-            } else {
-              console.log('No text to save on blur');
-            }
-            setEditingText(null);
-            setIsTextEditing(false);
-          }}
-          onKeyDown={(e) => {
-            console.log('Text input onKeyDown:', e.key);
-            // Let the global keyboard handler deal with Enter and Escape
-          }}
-          placeholder="Enter text..."
-          autoFocus
-          className="absolute bg-white border-2 border-blue-500 rounded px-2 py-1 text-sm font-mono shadow-lg outline-none min-w-[100px]"
-          style={{
-            left: editingText.position.x,
-            top: editingText.position.y - 30,
-            zIndex: 1000,
-          }}
+        <TextInputOverlay
+          editingText={editingText}
+          onChange={handleTextChange}
+          onBlur={handleTextBlur}
+          onKeyDown={handleTextKeyDown}
         />
       )}
       

--- a/src/components/TextInputOverlay.tsx
+++ b/src/components/TextInputOverlay.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react';
+import type { Point } from '@/src/model/types';
+
+interface EditingText {
+  position: Point;
+  currentText: string;
+}
+
+interface TextInputOverlayProps {
+  editingText: EditingText;
+  onChange: (value: string) => void;
+  onBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+}
+
+export default function TextInputOverlay({
+  editingText,
+  onChange,
+  onBlur,
+  onKeyDown,
+}: TextInputOverlayProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editingText.currentText === '' && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [editingText]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      value={editingText.currentText}
+      onChange={(e) => onChange(e.target.value)}
+      onBlur={onBlur}
+      onKeyDown={onKeyDown}
+      placeholder="Enter text..."
+      autoFocus
+      className="absolute bg-white border-2 border-blue-500 rounded px-2 py-1 text-sm font-mono shadow-lg outline-none min-w-[100px]"
+      style={{
+        left: editingText.position.x,
+        top: editingText.position.y - 30,
+        zIndex: 1000,
+      }}
+    />
+  );
+}

--- a/src/export/exportUtils.ts
+++ b/src/export/exportUtils.ts
@@ -30,5 +30,4 @@ export function downloadJSON() {
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
-  console.log("JSON model downloaded.");
 }

--- a/src/model/useStore.ts
+++ b/src/model/useStore.ts
@@ -233,11 +233,9 @@ const useStore = create<StoreState>()(
     })),
     connectWalls: (wallId1, wallId2) => {
       // Connect walls logic
-      console.log(`Connecting walls ${wallId1} and ${wallId2}`);
     },
     autoConnectNearbyWalls: (threshold) => {
       // Auto connect nearby walls logic
-      console.log(`Auto connecting walls within ${threshold} feet`);
     },
 
     // Flat Layout Actions
@@ -307,7 +305,6 @@ const useStore = create<StoreState>()(
     })),
     stitchPieces: () => {
       // Stitching logic for flat layout pieces
-      console.log('Stitching pieces together...');
     },
 
     // House Design Actions
@@ -410,7 +407,6 @@ const useStore = create<StoreState>()(
     })),
     calculateWireRuns: () => {
       // Wire run calculation logic
-      console.log('Calculating wire runs...');
     },
     updateWirePrices: (prices) => set(produce((draft: Model) => {
       Object.assign(draft.settings.wirePrices, prices);
@@ -498,7 +494,6 @@ const useStore = create<StoreState>()(
         }
       }
       
-      console.log('Building code validation completed');
     },
 
     // Selectors

--- a/src/tools/ConnectionTool.tsx
+++ b/src/tools/ConnectionTool.tsx
@@ -75,7 +75,6 @@ const ConnectionTool: React.FC<ConnectionToolProps> = ({ isActive }) => {
     };
 
     const connectionId = addConnection(connectionData);
-    console.log(`ConnectionTool: Created connection: ${connectionId}`);
     
     resetConnectionState();
   }, [selectedPiece1, selectedPiece2, selectedEdge1, selectedEdge2, connectionLength, addConnection, resetConnectionState]);

--- a/src/tools/FlatPieceTool.tsx
+++ b/src/tools/FlatPieceTool.tsx
@@ -63,7 +63,6 @@ const FlatPieceTool: React.FC<FlatPieceToolProps> = ({
         };
 
         const pieceId = addFlatPiece(newPiece);
-        console.log(`FlatPieceTool: Added ${pieceType} piece: ${pieceId}`);
         
         // Reset for next piece
         resetDrawingState();
@@ -78,7 +77,6 @@ const FlatPieceTool: React.FC<FlatPieceToolProps> = ({
 
   const handleFinishDrawing = useCallback(() => {
     if (isDrawing) {
-      console.log("FlatPieceTool: Finishing drawing session.");
     }
     resetDrawingState();
   }, [isDrawing, resetDrawingState]);

--- a/src/tools/FloorTool.tsx
+++ b/src/tools/FloorTool.tsx
@@ -112,11 +112,9 @@ const FloorTool: React.FC<FloorToolProps> = ({ isActive }) => {
         // onDrawingUpdate?.([], false);
         return;
       }
-       console.log("FloorTool: Points were counter-clockwise, automatically reversed.");
     }
 
     const area = calculatePolygonArea(finalPoints);
-    console.log(`FloorTool: Calculated area: ${area}`); // For debugging
 
     // Add floor to store (using default elevation/thickness for now)
     addFloor({
@@ -125,7 +123,6 @@ const FloorTool: React.FC<FloorToolProps> = ({ isActive }) => {
       thickness: 0.2, // Default thickness
     });
 
-    console.log("FloorTool: Floor added successfully.");
     setCurrentPoints([]);
     setIsDrawing(false);
     setError(null);

--- a/src/tools/OpeningTool.tsx
+++ b/src/tools/OpeningTool.tsx
@@ -59,7 +59,6 @@ const OpeningTool: React.FC<OpeningToolProps> = ({
       dimensions: { width: Number(width), height: Number(height) },
     };
 
-    console.log("Adding opening to wall:", selectedWall.id, openingData);
     addFlatOpening(selectedWall.id, openingData);
     // Optionally close the form/tool after adding
     // onClose();

--- a/src/tools/WallTool.tsx
+++ b/src/tools/WallTool.tsx
@@ -43,7 +43,6 @@ const WallTool: React.FC<WallToolProps> = ({ isActive /*, onDrawingUpdate */ }) 
         thickness: 0.15, // Default thickness
       };
       const newWallId = addWall(newWallDataOmitId);
-      console.log(`WallTool: Wall segment added: ${newWallId} from ${JSON.stringify(startPoint)} to ${JSON.stringify(point)}`);
 
       // Start a new wall segment from the current point
       setStartPoint(point);
@@ -63,7 +62,6 @@ const WallTool: React.FC<WallToolProps> = ({ isActive /*, onDrawingUpdate */ }) 
     // If a wall segment was just completed by a click, that segment is already saved.
     // This is more like an "Escape" or "Enter" key press to stop drawing further walls.
     if (isDrawing) {
-        console.log("WallTool: Finishing drawing session.");
     }
     resetDrawingState();
   }, [isDrawing, resetDrawingState]);


### PR DESCRIPTION
## Summary
- extract text input overlay into its own component for easier maintenance
- wire up focused text-editing handlers in `GraphCanvas`
- strip debug logging from canvas and tooling modules

## Testing
- `pnpm lint` *(fails: @typescript-eslint/no-use-before-define, no-array-index-key, Unexpected require, etc.)*
- `pnpm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68ad14776b30832ab18450e2b2207744